### PR TITLE
Render class

### DIFF
--- a/docs/class/render.md
+++ b/docs/class/render.md
@@ -1,0 +1,35 @@
+# Spyke Developer Docs
+## The *Render* Class
+
+`$Renderer = new Group8\Spyke\Render()`
+
+### add
+*Arguments*
+* str:	content
+
+#### content
+Appends to the <body> tag. This allows incremental additions to the body.
+
+**Example:**
+```php
+	$Renderer->add("<h1>Foo</h1>");
+	$Renderer->add("<h2>Bar</h2>");
+```
+*Output:*
+```buffer
+<h1>Foo</h1>\n
+<h2>Bar</h2>
+```
+
+### build
+*Arguments*
+* str:	title = `null`
+* bool:	exitAfterBuild = `false`
+
+**Example:**
+```php
+	$Renderer->build("Login", false);
+```
+*Output:*
+A full HTML page with the <title> "Spyke - Login",
+and due to `exitAfterBuild`, more code can be run.

--- a/src/Render.php
+++ b/src/Render.php
@@ -1,0 +1,49 @@
+<?php
+namespace Group8\Spyke;
+
+class Render
+{
+	// The <body> buffer. Things are to be appended to this.
+	private string $content;
+
+	// Adds content to the buffer.
+	public function add(string $content)
+	{
+		$this->content .= $content;
+	}
+
+	// Builds a final HTML output.
+	public function build (string $title=null, bool $exitAfterBuild=false)
+	{
+		$this->htmlHead($title);
+		print($this->content ?? "Whoops!"); // The ENTIRE content of <body>
+		$this->htmlTail();
+		if ($exitAfterBuild) {exit;}
+	}
+
+	// Generates the <head> block and begins the <body> block.
+    protected function htmlHead(string $title = null)
+    {
+		$coolTitle = isset($title)? " - {$title}": null;
+        echo <<< EOT
+		<!DOCTYPE html>
+		<html>
+		<head>
+			<link rel="stylesheet" type="text/css"  href="assets/css/homepage.css">
+			<meta charset="utf-8">
+			<meta name="viewport" content="width=device-width, initial-scale=1">
+			<title>Spyke$coolTitle</title>
+		</head>
+		<body>
+		EOT;
+    }
+
+	// Ends the <body> block and HTML.
+	protected function htmlTail()
+    {
+        echo <<< EOT
+		</body>
+		</html>
+		EOT;
+    }
+}

--- a/src/Render.php
+++ b/src/Render.php
@@ -9,7 +9,7 @@ class Render
 	// Adds content to the buffer.
 	public function add(string $content)
 	{
-		$this->content .= $content;
+		$this->content .= $content . "\n";
 	}
 
 	// Builds a final HTML output.


### PR DESCRIPTION
This pull adds the Render object, allowing HTML pages to easily be made anywhere in Spyke.

<body> content can be added with the `add($content)` method, which can be called multiple times to append more to the body.
Appending to the 'buffer' is useful for things from as basic as generic headers/footers to likely more complex tasks such as adding a bunch of posts in a loop.

It's up to you how you use it. A bunch of `add`s or just one.

Documentation is provided in `/docs/class/render.md`